### PR TITLE
Centers CRUD

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,8 +25,8 @@ jobs:
       - run: bundle exec rubocop -P
         name: Lint Ruby files
       
-#      - run: bundle exec erblint app/**/*.erb
-#        name: Lint ERB files
+      - run: bundle exec erblint app/**/*.erb
+        name: Lint ERB files
 
       - run: bundle exec mdl *.md
         name: Lint Markdown files

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,39 @@
 
 require "decidim/dev/common_rake"
 
+def install_module(path)
+  Dir.chdir(path) do
+    system("bundle exec rake decidim_centers:install:migrations")
+    system("bundle exec rake db:migrate")
+  end
+end
+
+def seed_db(path)
+  Dir.chdir(path) do
+    system("bundle exec rake db:seed")
+  end
+end
+
 desc "Generates a dummy app for testing"
-task test_app: "decidim:generate_external_test_app"
+task test_app: "decidim:generate_external_test_app" do
+  ENV["RAILS_ENV"] = "test"
+  install_module("spec/decidim_dummy_app")
+end
 
 desc "Generates a development app."
-task development_app: "decidim:generate_external_development_app"
+task :development_app do
+  Bundler.with_original_env do
+    generate_decidim_app(
+      "development_app",
+      "--app_name",
+      "#{base_app_name}_development_app",
+      "--path",
+      "..",
+      "--recreate_db",
+      "--demo"
+    )
+  end
+
+  install_module("development_app")
+  seed_db("development_app")
+end

--- a/app/commands/decidim/centers/admin/create_center.rb
+++ b/app/commands/decidim/centers/admin/create_center.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Centers
+    module Admin
+      # This command is executed when the user creates a Center from the admin
+      # panel.
+      class CreateCenter < Decidim::Command
+        # Initializes a CreateCenter Command.
+        #
+        # form - The form from which to get the data.
+        # current_user - The user who performs the action.
+        def initialize(form, current_user)
+          @form = form
+          @current_user = current_user
+        end
+
+        # Creates the center if valid.
+        #
+        # Broadcasts :ok if successful, :invalid otherwise.
+        def call
+          return broadcast(:invalid) if form.invalid?
+
+          transaction do
+            create_center!
+          end
+
+          broadcast(:ok, @center)
+        end
+
+        private
+
+        attr_reader :form, :current_user
+
+        def create_center!
+          attributes = {
+            organization: form.current_organization,
+            title: form.title
+          }
+
+          @center = Decidim.traceability.create!(
+            Center,
+            current_user,
+            attributes
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/commands/decidim/centers/admin/destroy_center.rb
+++ b/app/commands/decidim/centers/admin/destroy_center.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Centers
+    module Admin
+      # This command is executed when the user destroys a Center from the admin
+      # panel.
+      class DestroyCenter < Decidim::Command
+        # Initializes a DestroyCenter Command.
+        #
+        # center - The current instance of the center to be destroyed.
+        # current_user - The user who performs the action.
+        def initialize(center, current_user)
+          @center = center
+          @current_user = current_user
+        end
+
+        # Destroys the center if valid.
+        #
+        # Broadcasts :ok if successful, :invalid otherwise.
+        def call
+          transaction do
+            destroy_center!
+          end
+
+          broadcast(:ok, center)
+        end
+
+        private
+
+        attr_reader :center, :current_user
+
+        def destroy_center!
+          attributes = {
+            deleted_at: Time.current
+          }
+
+          Decidim.traceability.update!(
+            center,
+            current_user,
+            attributes
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/commands/decidim/centers/admin/update_center.rb
+++ b/app/commands/decidim/centers/admin/update_center.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Centers
+    module Admin
+      # This command is executed when the user changes a Center from the admin
+      # panel.
+      class UpdateCenter < Decidim::Command
+        # Initializes a UpdateCenter Command.
+        #
+        # form - The form from which to get the data.
+        # center - The current instance of the center to be updated.
+        # current_user - The user who performs the action.
+        def initialize(form, center, current_user)
+          @form = form
+          @center = center
+          @current_user = current_user
+        end
+
+        # Updates the center if valid.
+        #
+        # Broadcasts :ok if successful, :invalid otherwise.
+        def call
+          return broadcast(:invalid) if form.invalid?
+
+          transaction do
+            update_center!
+          end
+
+          broadcast(:ok, center)
+        end
+
+        private
+
+        attr_reader :form, :center, :current_user
+
+        def update_center!
+          Decidim.traceability.update!(
+            center,
+            current_user,
+            title: form.title
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/centers/admin/application_controller.rb
+++ b/app/controllers/decidim/centers/admin/application_controller.rb
@@ -9,6 +9,15 @@ module Decidim
       # Note that it inherits from `Decidim::Admin::ApplicationController`, which
       # override its layout and provide all kinds of useful methods.
       class ApplicationController < Decidim::Admin::ApplicationController
+        register_permissions(::Decidim::Centers::Admin::ApplicationController,
+                             ::Decidim::Centers::Admin::Permissions,
+                             ::Decidim::Admin::Permissions)
+
+        private
+
+        def permission_class_chain
+          ::Decidim.permissions_registry.chain_for(::Decidim::Centers::Admin::ApplicationController)
+        end
       end
     end
   end

--- a/app/controllers/decidim/centers/admin/centers_controller.rb
+++ b/app/controllers/decidim/centers/admin/centers_controller.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Centers
+    module Admin
+      # This controller allows the create or update a center.
+      class CentersController < ApplicationController
+        helper_method :centers, :center
+
+        def new
+          enforce_permission_to :create, :center
+          @form = form(CenterForm).instance
+        end
+
+        def create
+          enforce_permission_to :create, :center
+          @form = form(CenterForm).from_params(params)
+
+          CreateCenter.call(@form, current_user) do
+            on(:ok) do
+              flash[:notice] = I18n.t("centers.create.success", scope: "decidim.centers.admin")
+              redirect_to centers_path
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("centers.create.invalid", scope: "decidim.centers.admin")
+              render action: "new"
+            end
+          end
+        end
+
+        def edit
+          enforce_permission_to :update, :center, center: center
+          @form = form(CenterForm).from_model(center)
+        end
+
+        def update
+          enforce_permission_to :update, :center, center: center
+          @form = form(CenterForm).from_params(params)
+
+          UpdateCenter.call(@form, center, current_user) do
+            on(:ok) do
+              flash[:notice] = I18n.t("centers.update.success", scope: "decidim.centers.admin")
+              redirect_to centers_path
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("centers.update.invalid", scope: "decidim.centers.admin")
+              render action: "edit"
+            end
+          end
+        end
+
+        def destroy
+          enforce_permission_to :destroy, :center, center: center
+
+          DestroyCenter.call(center, current_user) do
+            on(:ok) do
+              flash[:notice] = I18n.t("centers.destroy.success", scope: "decidim.centers.admin")
+            end
+          end
+
+          redirect_to centers_path
+        end
+
+        private
+
+        def center
+          @center ||= filtered_centers.find(params[:id])
+        end
+
+        def centers
+          @centers ||= filtered_centers.page(params[:page]).per(15)
+        end
+
+        def filtered_centers
+          Center.where(organization: current_organization).not_deleted
+        end
+      end
+    end
+  end
+end

--- a/app/forms/decidim/centers/admin/center_form.rb
+++ b/app/forms/decidim/centers/admin/center_form.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Centers
+    module Admin
+      # This class holds a Form to update centers from Decidim's admin panel.
+      class CenterForm < Decidim::Form
+        include TranslatableAttributes
+
+        translatable_attribute :title, String
+
+        validates :title, translatable_presence: true
+
+        alias organization current_organization
+      end
+    end
+  end
+end

--- a/app/models/decidim/centers/center.rb
+++ b/app/models/decidim/centers/center.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Centers
+    class Center < Centers::ApplicationRecord
+      include Decidim::TranslatableResource
+
+      translatable_fields :title
+
+      belongs_to :organization,
+                 foreign_key: "decidim_organization_id",
+                 class_name: "Decidim::Organization"
+
+      scope :not_deleted, -> { where(deleted_at: nil) }
+
+      def deleted?
+        deleted_at.present?
+      end
+
+      def self.log_presenter_class_for(_log)
+        Decidim::Centers::AdminLog::CenterPresenter
+      end
+    end
+  end
+end

--- a/app/permissions/decidim/centers/admin/permissions.rb
+++ b/app/permissions/decidim/centers/admin/permissions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Centers
+    module Admin
+      class Permissions < Decidim::DefaultPermissions
+        def permissions
+          return permission_action unless user
+          return permission_action unless user.admin?
+          return permission_action unless permission_action.scope == :admin
+          return permission_action unless permission_action.subject == :center
+
+          allow!
+          permission_action
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/decidim/centers/admin_log/center_presenter.rb
+++ b/app/presenters/decidim/centers/admin_log/center_presenter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Centers
+    module AdminLog
+      # This class holds the logic to present a `Decidim::Centers::Center`
+      # for the `AdminLog` log.
+      #
+      # Usage should be automatic and you shouldn't need to call this class
+      # directly, but here's an example:
+      #
+      #    action_log = Decidim::ActionLog.last
+      #    view_helpers # => this comes from the views
+      #    CenterPresenter.new(action_log, view_helpers).present
+      class CenterPresenter < Decidim::Log::BasePresenter
+        private
+
+        def action_string
+          case action
+          when "create", "delete", "update"
+            "decidim.centers.admin_log.center.#{action}"
+          else
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/decidim/centers/admin/centers/_form.html.erb
+++ b/app/views/decidim/centers/admin/centers/_form.html.erb
@@ -1,0 +1,10 @@
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title"><%= title %></h2>
+  </div>
+  <div class="card-section">
+    <div class="row column">
+      <%= form.translated :text_field, :title, autofocus: true %>
+    </div>
+  </div>
+</div>

--- a/app/views/decidim/centers/admin/centers/edit.html.erb
+++ b/app/views/decidim/centers/admin/centers/edit.html.erb
@@ -1,0 +1,8 @@
+<% add_decidim_page_title(t(".title")) %>
+<%= decidim_form_for(@form, html: { class: "form edit_center" }) do |f| %>
+  <%= render partial: "form", object: f, locals: { title: t(".title") } %>
+
+  <div class="button--double form-general-submit">
+    <%= f.submit t(".save") %>
+  </div>
+<% end %>

--- a/app/views/decidim/centers/admin/centers/index.html.erb
+++ b/app/views/decidim/centers/admin/centers/index.html.erb
@@ -1,0 +1,45 @@
+<% add_decidim_page_title(t(".title")) %>
+<div class="card">
+  <div class="card-divider">
+    <h2 class="card-title">
+      <%= t(".title") %>
+      <%= link_to t("actions.new", scope: "decidim.centers", name: t("models.center.name", scope: "decidim.centers.admin")), new_center_path, class: "button tiny button--title" if allowed_to? :create, :center %>
+    </h2>
+  </div>
+
+  <div class="card-section">
+    <div class="table-scroll">
+      <table class="table-list centers">
+        <thead>
+          <tr>
+            <th><%= t("models.center.fields.title", scope: "decidim.centers") %></th>
+            <th><%= t("models.center.fields.created_at", scope: "decidim.centers") %></th>
+            <th class="actions"><%= t("actions.title", scope: "decidim.centers") %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% centers.each do |center| %>
+            <tr data-id="<%= center.id %>">
+              <td>
+                <%= translated_attribute(center.title) %><br>
+              </td>
+              <td>
+                <%= l center.created_at, format: "%d/%m/%Y - %H:%M" %>
+              </td>
+              <td class="table-list__actions">
+                <% if allowed_to? :update, :center, center: center %>
+                  <%= icon_link_to "pencil", edit_center_path(center), t("actions.edit", scope: "decidim.centers"), class: "action-icon--edit" %>
+                <% end %>
+
+                <% if allowed_to? :destroy, :center, center: center %>
+                  <%= icon_link_to "circle-x", center_path(center), t("actions.destroy", scope: "decidim.centers"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.centers") } %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%= paginate centers, theme: "decidim" %>
+    </div>
+  </div>
+</div>

--- a/app/views/decidim/centers/admin/centers/new.html.erb
+++ b/app/views/decidim/centers/admin/centers/new.html.erb
@@ -1,0 +1,8 @@
+<% add_decidim_page_title(t(".title")) %>
+<%= decidim_form_for(@form, html: { class: "form new_center" }) do |f| %>
+  <%= render partial: "form", object: f, locals: { title: t(".title") } %>
+
+  <div class="button--double form-general-submit">
+      <%= f.submit t(".create") %>
+  </div>
+<% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -5,3 +5,6 @@ locales: [en]
 
 ignore_missing:
   - decidim.participatory_processes.scopes.global
+
+ignore_unused:
+  - decidim.centers.admin_log.*

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,2 +1,41 @@
 ---
 en:
+  decidim:
+    centers:
+      actions:
+        confirm_destroy: Are you sure you want to delete this center?
+        destroy: Delete
+        edit: Edit
+        new: New center
+        title: Actions
+      admin:
+        centers:
+          create:
+            invalid: There was a problem creating this center
+            success: Center successfully created
+          destroy:
+            success: Center successfully deleted
+          edit:
+            save: Update
+            title: Edit center
+          index:
+            title: Centers
+          new:
+            create: Create
+            title: Create center
+          update:
+            invalid: There was a problem saving the center.
+            success: Center successfully saved
+        models:
+          center:
+            name: Center
+      admin_log:
+        center:
+          create: "%{user_name} created the %{resource_name} center"
+          delete: "%{user_name} deleted the %{resource_name} center"
+          update: "%{user_name} updated the %{resource_name} center"
+      models:
+        center:
+          fields:
+            created_at: Created at
+            title: Title

--- a/db/migrate/20231129114029_create_decidim_centers_centers.rb
+++ b/db/migrate/20231129114029_create_decidim_centers_centers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateDecidimCentersCenters < ActiveRecord::Migration[6.1]
+  def change
+    create_table :decidim_centers_centers do |t|
+      t.references :decidim_organization, foreign_key: true, index: true
+      t.jsonb :title, null: false
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/decidim/centers/admin_engine.rb
+++ b/lib/decidim/centers/admin_engine.rb
@@ -10,13 +10,25 @@ module Decidim
       paths["lib/tasks"] = nil
 
       routes do
-        # Add admin engine routes here
-        # resources :centers do
-        #   collection do
-        #     resources :exports, only: [:create]
-        #   end
-        # end
-        # root to: "centers#index"
+        resources :centers
+        root to: "centers#index"
+      end
+
+      initializer "decidim_centers.admin_mount_routes" do
+        Decidim::Core::Engine.routes do
+          mount Decidim::Centers::AdminEngine, at: "/admin/centers", as: "decidim_admin_centers"
+        end
+      end
+
+      initializer "decidim_centers.admin_menu" do
+        Decidim.menu :admin_menu do |menu|
+          menu.add_item :centers,
+                        I18n.t("menu.centers", scope: "decidim.admin", default: "Centers"),
+                        decidim_admin_centers.centers_path,
+                        icon_name: "home",
+                        position: 15,
+                        active: :inclusive
+        end
       end
 
       def load_seed

--- a/lib/decidim/centers/test/factories.rb
+++ b/lib/decidim/centers/test/factories.rb
@@ -4,4 +4,13 @@ require "decidim/core/test/factories"
 
 FactoryBot.define do
   # Add engine factories here
+  factory :center, class: "Decidim::Centers::Center" do
+    organization { create(:organization) }
+    title { generate_localized_title }
+    deleted_at { nil }
+
+    trait :deleted do
+      deleted_at { Time.current }
+    end
+  end
 end

--- a/lib/decidim/centers/test/factories.rb
+++ b/lib/decidim/centers/test/factories.rb
@@ -3,7 +3,6 @@
 require "decidim/core/test/factories"
 
 FactoryBot.define do
-  # Add engine factories here
   factory :center, class: "Decidim::Centers::Center" do
     organization { create :organization }
     title { generate_localized_title }

--- a/lib/decidim/centers/test/factories.rb
+++ b/lib/decidim/centers/test/factories.rb
@@ -5,7 +5,7 @@ require "decidim/core/test/factories"
 FactoryBot.define do
   # Add engine factories here
   factory :center, class: "Decidim::Centers::Center" do
-    organization { create(:organization) }
+    organization { create :organization }
     title { generate_localized_title }
     deleted_at { nil }
 

--- a/spec/commands/decidim/centers/admin/create_center_spec.rb
+++ b/spec/commands/decidim/centers/admin/create_center_spec.rb
@@ -17,7 +17,7 @@ module Decidim
           double(
             invalid?: invalid,
             title: { en: title },
-            current_organization: organization,
+            current_organization: organization
           )
         end
 

--- a/spec/commands/decidim/centers/admin/create_center_spec.rb
+++ b/spec/commands/decidim/centers/admin/create_center_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Centers
+    module Admin
+      describe CreateCenter do
+        subject { described_class.new(form, current_user) }
+
+        let(:organization) { create :organization }
+        let(:current_user) { create :user, organization: organization }
+        let(:title) { "Center title" }
+
+        let(:invalid) { false }
+        let(:form) do
+          double(
+            invalid?: invalid,
+            title: { en: title },
+            current_organization: organization,
+          )
+        end
+
+        context "when the form is not valid" do
+          let(:invalid) { true }
+
+          it "is not valid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when everything is ok" do
+          let(:center) { Center.last }
+
+          it "creates the center" do
+            expect { subject.call }.to change(Center, :count).by(1)
+          end
+
+          it "sets the title" do
+            subject.call
+            expect(translated(center.title)).to eq title
+          end
+
+          it "broadcasts ok" do
+            expect { subject.call }.to broadcast(:ok)
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:create!)
+              .with(Center, current_user, kind_of(Hash))
+              .and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count)
+
+            expect(Decidim::ActionLog.last.resource).to eq center
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/decidim/centers/admin/destroy_center_spec.rb
+++ b/spec/commands/decidim/centers/admin/destroy_center_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Centers
+    module Admin
+      describe DestroyCenter do
+        subject { described_class.new(center, current_user) }
+
+        let(:organization) { create :organization }
+        let(:current_user) { create :user, organization: organization }
+        let(:center) { create :center, organization: organization }
+
+        context "when everything is ok" do
+          it "updates the deleted_at" do
+            expect(center.deleted?).to be false
+            subject.call
+            expect(center.deleted?).to be true
+          end
+
+          it "broadcasts ok" do
+            expect { subject.call }.to broadcast(:ok)
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:update!)
+              .and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count)
+
+            expect(Decidim::ActionLog.last.resource).to eq center
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/decidim/centers/admin/update_center_spec.rb
+++ b/spec/commands/decidim/centers/admin/update_center_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Centers
+    module Admin
+      describe UpdateCenter do
+        subject { described_class.new(form, center, current_user) }
+
+        let(:organization) { create :organization }
+        let(:current_user) { create :user, organization: organization }
+        let(:title) { "Center title" }
+        let(:center) { create :center, organization: organization }
+        let(:invalid) { false }
+        let(:form) do
+          double(
+            invalid?: invalid,
+            title: { en: title },
+            current_organization: organization
+          )
+        end
+
+        context "when the form is not valid" do
+          let(:invalid) { true }
+
+          it "is not valid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't update the center" do
+            expect(center).not_to receive(:update!)
+            subject.call
+          end
+        end
+
+        context "when everything is ok" do
+          let(:title) { "Center title updated" }
+
+          it "updates the title" do
+            subject.call
+            expect(translated(center.title)).to eq title
+          end
+
+          it "broadcasts ok" do
+            expect { subject.call }.to broadcast(:ok)
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:update!)
+              .with(center, current_user, { title: { en: title } })
+              .and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count)
+
+            expect(Decidim::ActionLog.last.resource).to eq center
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/decidim/centers/admin/centers_controller_spec.rb
+++ b/spec/controllers/decidim/centers/admin/centers_controller_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Centers
+    module Admin
+      describe CentersController, type: :controller do
+        routes { Decidim::Centers::AdminEngine.routes }
+
+        let(:organization) { create :organization }
+        let(:user) { create :user, :admin, :confirmed, organization: organization }
+        let!(:centers) { create_list :center, 20, organization: organization }
+
+        before do
+          request.env["decidim.current_organization"] = organization
+          sign_in user, scope: :user
+        end
+
+        describe "#index" do
+          it "renders the index template" do
+            get :index
+
+            expect(response).to render_template(:index)
+          end
+        end
+
+        describe "#new" do
+          it "renders the new template" do
+            get :new
+
+            expect(response).to render_template(:new)
+          end
+        end
+
+        describe "#edit" do
+          let(:params) do
+            {
+              id: id
+            }
+          end
+
+          context "with valid params" do
+            let(:id) { centers.first.id }
+
+            it "renders the edit template" do
+              get :edit, params: params
+
+              expect(response).to render_template(:edit)
+            end
+          end
+
+          context "with non existing record" do
+            let(:id) { -1 }
+
+            it "raise not found exception" do
+              expect { get :edit, params: params }.to raise_error(ActiveRecord::RecordNotFound)
+            end
+          end
+        end
+
+        describe "#create" do
+          let(:params) do
+            {
+              title: {
+                en: title
+              }
+            }
+          end
+
+          context "with invalid params" do
+            let(:title) { "" }
+
+            it "renders the new template" do
+              post :create, params: params
+
+              expect(response).to render_template(:new)
+            end
+          end
+
+          context "with valid params" do
+            let(:title) { "My title" }
+
+            it "redirects to index" do
+              expect(controller).to receive(:redirect_to) do |params|
+                expect(params).to eq("/centers")
+              end
+
+              post :create, params: params
+            end
+          end
+        end
+
+        describe "#update" do
+          let(:params) do
+            {
+              id: id,
+              title: {
+                en: title
+              }
+            }
+          end
+
+          context "with existing record" do
+            let(:id) { centers.first.id }
+
+            context "with invalid params" do
+              let(:title) { "" }
+
+              it "renders the edit template" do
+                put :update, params: params
+
+                expect(response).to render_template(:edit)
+              end
+            end
+
+            context "with valid params" do
+              let(:title) { "My title" }
+
+              it "redirects to index" do
+                expect(controller).to receive(:redirect_to) do |params|
+                  expect(params).to eq("/centers")
+                end
+
+                put :update, params: params
+              end
+            end
+          end
+
+          context "with non existing record" do
+            let(:id) { -1 }
+            let(:title) { "My title" }
+
+            it "raise not found exception" do
+              expect { put :update, params: params }.to raise_error(ActiveRecord::RecordNotFound)
+            end
+          end
+        end
+
+        describe "#destroy" do
+          let(:params) do
+            {
+              id: id
+            }
+          end
+
+          context "with existing record" do
+            let(:id) { centers.first.id }
+
+            it "redirects to index" do
+              expect(controller).to receive(:redirect_to) do |params|
+                expect(params).to eq("/centers")
+              end
+
+              delete :destroy, params: params
+            end
+          end
+
+          context "with non existing record" do
+            let(:id) { -1 }
+
+            it "raise not found exception" do
+              expect { delete :destroy, params: params }.to raise_error(ActiveRecord::RecordNotFound)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/decidim/centers/admin/center_form_spec.rb
+++ b/spec/forms/decidim/centers/admin/center_form_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Centers
+    module Admin
+      describe CenterForm do
+        subject do
+          described_class.from_params(attributes).with_context(
+            current_organization: current_organization
+          )
+        end
+
+        let(:current_organization) { create :organization }
+
+        let(:title) do
+          {
+            "en" => "Title",
+            "ca" => "Títol",
+            "es" => "Título"
+          }
+        end
+
+        let(:attributes) do
+          {
+            "center" => {
+              "title" => title
+            }
+          }
+        end
+
+        context "when everything is OK" do
+          it { is_expected.to be_valid }
+        end
+
+        context "when title is missing" do
+          let(:title) do
+            { "en" => "" }
+          end
+
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+  end
+end

--- a/spec/models/decidim/centers/center_spec.rb
+++ b/spec/models/decidim/centers/center_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Centers
+    describe Center do
+      subject { center }
+
+      let(:center) { create :center }
+
+      it { is_expected.to be_valid }
+
+      describe "deleted?" do
+        subject { center.deleted? }
+
+        context "when not deleted" do
+          it { is_expected.to be false }
+        end
+
+        context "when deleted" do
+          let(:center) { create :center, :deleted }
+
+          it { is_expected.to be true }
+        end
+      end
+
+      describe "not_deleted" do
+        subject { described_class.not_deleted }
+
+        let!(:centers) { create_list :center, 5 }
+        let!(:deleted_centers) { create_list :center, 3, :deleted }
+
+        it "returns not deleted centers" do
+          expect(subject.count).to be 5
+          expect(described_class.count).to be 8
+        end
+      end
+    end
+  end
+end

--- a/spec/permissions/decidim/centers/admin/permissions_spec.rb
+++ b/spec/permissions/decidim/centers/admin/permissions_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Centers
+    module Admin
+      describe Permissions do
+        subject { described_class.new(user, permission_action, context).permissions.allowed? }
+
+        let(:user) { create :user, :admin, organization: center.organization }
+        let(:context) do
+          {
+            center: center
+          }
+        end
+        let(:center) { create :center }
+        let(:permission_action) { Decidim::PermissionAction.new(**action) }
+
+        context "when scope is admin" do
+          let(:action) do
+            { scope: :admin, action: :foo, subject: :center }
+          end
+
+          it { is_expected.to be true }
+        end
+
+        context "when no user" do
+          let(:user) { nil }
+
+          let(:action) do
+            { scope: :admin, action: :foo, subject: :center }
+          end
+
+          it_behaves_like "permission is not set"
+        end
+
+        context "when user is not admin" do
+          let(:user) { create :user, organization: center.organization }
+
+          let(:action) do
+            { scope: :admin, action: :foo, subject: :center }
+          end
+
+          it_behaves_like "permission is not set"
+        end
+
+        context "when scope is a random one" do
+          let(:action) do
+            { scope: :foo, action: :foo, subject: :center }
+          end
+
+          it_behaves_like "permission is not set"
+        end
+
+        context "when subject is a random one" do
+          let(:action) do
+            { scope: :admin, action: :foo, subject: :foo }
+          end
+
+          it_behaves_like "permission is not set"
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/decidim/centers/admin_log/center_presenter_spec.rb
+++ b/spec/presenters/decidim/centers/admin_log/center_presenter_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Centers
+    module AdminLog
+      describe CenterPresenter, type: :helper do
+        let(:admin_log_resource) { create :center }
+
+        context "when action is create" do
+          include_examples "present admin log entry" do
+            let(:action) { "create" }
+          end
+        end
+
+        context "when action is delete" do
+          include_examples "present admin log entry" do
+            let(:action) { "delete" }
+          end
+        end
+
+        context "when action is update" do
+          include_examples "present admin log entry" do
+            let(:action) { "update" }
+          end
+        end
+
+        context "when action is other" do
+          include_examples "present admin log entry" do
+            let(:action) { "other" }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/admin_manages_centers_spec.rb
+++ b/spec/system/admin_manages_centers_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages centers", type: :system do
+  let(:organization) { create :organization }
+  let(:user) { create :user, :admin, :confirmed, organization: organization }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin.root_path
+  end
+
+  def visit_centers_path
+    visit decidim_admin_centers.centers_path
+  end
+
+  def visit_edit_center_path(center)
+    visit decidim_admin_centers.edit_center_path(center)
+  end
+
+  it "renders the expected menu" do
+    within ".main-nav" do
+      expect(page).to have_content("Centers")
+    end
+
+    click_link "Centers"
+
+    expect(page).to have_content("Centers")
+  end
+
+  context "when visiting centers path" do
+    before do
+      visit_centers_path
+    end
+
+    it "shows new center button" do
+      expect(page).to have_content("New center")
+    end
+
+    context "when no centers created" do
+      it "shows an empty table" do
+        expect(page).to have_no_selector("table.table-list.centers tbody tr")
+      end
+    end
+
+    context "when centers created" do
+      let!(:centers) { create_list :center, 5, organization: organization }
+      let(:center) { centers.first }
+
+      before do
+        visit_centers_path
+      end
+
+      it "shows table rows" do
+        expect(page).to have_selector("table.table-list.centers tbody tr", count: 5)
+      end
+
+      it "shows all the centers" do
+        centers.each do |center|
+          expect(page).to have_content(center.title["en"])
+        end
+      end
+
+      it "can create center and show the action in the admin log" do
+        find(".card-title a.button").click
+
+        fill_in_i18n(
+          :center_title,
+          "#center-title-tabs",
+          en: "My center"
+        )
+
+        within ".new_center" do
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_admin_callout("successfully")
+
+        within "table" do
+          expect(page).to have_content("My center")
+        end
+
+        click_link "Dashboard"
+
+        expect(page).to have_content("created the My center center")
+      end
+
+      it "cannot create an invalid center" do
+        find(".card-title a.button").click
+
+        within ".new_center" do
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_admin_callout("problem")
+      end
+
+      it "can edit center and show the action in the admin log" do
+        within find("tr", text: translated(center.title)) do
+          click_link "Edit"
+        end
+
+        fill_in_i18n(
+          :center_title,
+          "#center-title-tabs",
+          en: "My edited center"
+        )
+
+        within ".edit_center" do
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_admin_callout("successfully")
+        expect(page).to have_content("My edited center")
+
+        click_link "Dashboard"
+
+        expect(page).to have_content("updated the My edited center center")
+      end
+
+      it "cannot save an edited invalid center" do
+        within find("tr", text: translated(center.title)) do
+          click_link "Edit"
+        end
+
+        fill_in_i18n(
+          :center_title,
+          "#center-title-tabs",
+          en: ""
+        )
+
+        within ".edit_center" do
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_admin_callout("problem")
+      end
+
+      it "can delete center" do
+        within find("tr", text: translated(center.title)) do
+          accept_confirm { click_link "Delete" }
+        end
+
+        expect(page).to have_admin_callout("successfully")
+
+        within "table" do
+          expect(page).to have_no_content(translated(center.title))
+          expect(page).to have_selector("table.table-list.centers tbody tr", count: 4)
+        end
+      end
+
+      context "when center from other organization" do
+        let(:other_organization) { create :organization }
+        let!(:center) { create :center, organization: other_organization }
+
+        it "does not show the it" do
+          visit_centers_path
+
+          expect(page).not_to have_content(center.title["en"])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1 

- [x] Allow admin to create, update, and delete centers from the admin panel.
- [x] A center has a translatable title.
- [x] A center belongs to an organization.
- [x] The centers have logical removal so they are never deleted physically from the database.

https://github.com/Platoniq/decidim-module-centers/assets/6973564/773f0f40-ec48-4a6f-9db3-b9016da07255