### PR TITLE
Register scope by user and include them in the center authorization

### DIFF
--- a/app/commands/concerns/decidim/centers/publish_center_update_event.rb
+++ b/app/commands/concerns/decidim/centers/publish_center_update_event.rb
@@ -11,7 +11,8 @@ module Decidim
         ActiveSupport::Notifications.publish(
           "decidim.centers.user.updated",
           user_id: @user.id,
-          center_id: @form.center_id
+          center_id: @form.center_id,
+          scope_id: @form.scope_id
         )
       end
     end

--- a/app/commands/decidim/centers/create_or_update_scope_user.rb
+++ b/app/commands/decidim/centers/create_or_update_scope_user.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Centers
+    # This command is executed when a new relationship between user
+    # and scope is created
+    class CreateOrUpdateScopeUser < Decidim::Command
+      # Initializes a CreateOrUpdateScopeUser Command.
+      #
+      # scope - The scope to be related with the user.
+      # user - The user to be related with the scope.
+      def initialize(scope, user)
+        @scope = scope
+        @user = user
+      end
+
+      # Creates or update the scope user if valid.
+      #
+      # Broadcasts :ok if successful, :invalid otherwise.
+      def call
+        transaction do
+          delete_existing_scope_user!
+          create_scope_user!
+        rescue ActiveRecord::RecordInvalid
+          broadcast(:invalid)
+        end
+
+        broadcast(:ok, @scope_user)
+      end
+
+      private
+
+      attr_reader :scope, :user
+
+      def delete_existing_scope_user!
+        ScopeUser.where(user: user).destroy_all
+      end
+
+      def create_scope_user!
+        @scope_user = ScopeUser.create!(scope: scope, user: user)
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/decidim/centers/with_scopes_helper.rb
+++ b/app/controllers/concerns/decidim/centers/with_scopes_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Centers
+    module WithScopesHelper
+      extend ActiveSupport::Concern
+
+      included do
+        helper Decidim::ScopesHelper
+      end
+    end
+  end
+end

--- a/app/forms/concerns/decidim/centers/account_form_override.rb
+++ b/app/forms/concerns/decidim/centers/account_form_override.rb
@@ -13,13 +13,22 @@ module Decidim
         include Decidim::Centers::ApplicationHelper
 
         attribute :center_id, Integer
+        attribute :scope_id, Integer
 
         validates :center_id, presence: true
+        validates :scope_id, presence: true, if: :scope_id?
 
         def map_model(model)
           original_map_model(model)
 
           self.center_id = model.center.try(:id)
+          self.scope_id = model.scope.try(:id)
+        end
+
+        private
+
+        def scope_id?
+          Decidim::Centers.scopes_enabled
         end
       end
     end

--- a/app/forms/decidim/centers/verifications/center.rb
+++ b/app/forms/decidim/centers/verifications/center.rb
@@ -7,10 +7,12 @@ module Decidim
     module Verifications
       class Center < Decidim::AuthorizationHandler
         validate :center_present
+        validate :scope_present
 
         def metadata
           super.merge(
-            centers: user.centers.pluck(:id)
+            centers: user.centers.pluck(:id),
+            scopes: user.scopes.pluck(:id)
           )
         end
 
@@ -18,6 +20,12 @@ module Decidim
 
         def center_present
           errors.add(:user, I18n.t("decidim.centers.authorizations.new.error")) unless user.centers.any?
+        end
+
+        def scope_present
+          return unless Decidim::Centers.scopes_enabled
+
+          errors.add(:user, I18n.t("decidim.centers.authorizations.new.error")) unless user.scopes.any?
         end
       end
     end

--- a/app/jobs/decidim/centers/auto_verification_job.rb
+++ b/app/jobs/decidim/centers/auto_verification_job.rb
@@ -7,7 +7,7 @@ module Decidim
 
       def perform(user_id)
         @user = Decidim::User.find(user_id)
-        @user.centers.any? ? create_auth : remove_auth
+        @user.centers.any? || @user.scopes.any? ? create_auth : remove_auth
       rescue ActiveRecord::RecordNotFound => _e
         Rails.logger.error "AutoVerificationJob: ERROR: user not found #{user_id}"
       end

--- a/app/jobs/decidim/centers/sync_scope_user_job.rb
+++ b/app/jobs/decidim/centers/sync_scope_user_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Centers
+    class SyncScopeUserJob < ApplicationJob
+      queue_as :default
+
+      def perform(data)
+        @user = Decidim::User.find(data[:user_id])
+        @scope = Decidim::Scope.find(data[:scope_id])
+        create_or_update_scope_user
+      end
+
+      private
+
+      def create_or_update_scope_user
+        Decidim::Centers::CreateOrUpdateScopeUser.call(@scope, @user) do
+          on(:ok) do
+            Rails.logger.info "SyncScopeUserJob: Success: updated for user #{@user.id}"
+          end
+
+          on(:invalid) do
+            Rails.logger.error "SyncScopeUserJob: ERROR: not updated for user #{@user.id}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/decidim/centers/unique_by_user.rb
+++ b/app/models/concerns/decidim/centers/unique_by_user.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Centers
+    module UniqueByUser
+      extend ActiveSupport::Concern
+
+      included do
+        validate :unique_by_user
+
+        def unique_by_user
+          return if self.class.where(user: user).empty?
+
+          errors.add(:user, :invalid)
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/decidim/centers/user_override.rb
+++ b/app/models/concerns/decidim/centers/user_override.rb
@@ -13,8 +13,19 @@ module Decidim
 
         has_many :centers, through: :center_users
 
+        has_many :scope_users,
+                 class_name: "Decidim::Centers::ScopeUser",
+                 foreign_key: "decidim_user_id",
+                 dependent: :destroy
+
+        has_many :scopes, through: :scope_users
+
         def center
           centers.first
+        end
+
+        def scope
+          scopes.first
         end
       end
     end

--- a/app/models/decidim/centers/scope_user.rb
+++ b/app/models/decidim/centers/scope_user.rb
@@ -2,12 +2,12 @@
 
 module Decidim
   module Centers
-    class CenterUser < Centers::ApplicationRecord
+    class ScopeUser < Centers::ApplicationRecord
       include UniqueByUser
 
-      belongs_to :center,
-                 foreign_key: "decidim_centers_center_id",
-                 class_name: "Decidim::Centers::Center"
+      belongs_to :scope,
+                 foreign_key: "decidim_scope_id",
+                 class_name: "Decidim::Scope"
 
       belongs_to :user,
                  foreign_key: "decidim_user_id",
@@ -18,9 +18,9 @@ module Decidim
       private
 
       def same_organization
-        return if center.try(:organization) == user.try(:organization)
+        return if scope.try(:organization) == user.try(:organization)
 
-        errors.add(:center, :invalid)
+        errors.add(:scope, :invalid)
         errors.add(:user, :invalid)
       end
     end

--- a/app/views/decidim/centers/_profile_form.html.erb
+++ b/app/views/decidim/centers/_profile_form.html.erb
@@ -1,1 +1,5 @@
 <%= f.collection_select :center_id, f.object.center_options_for_select, :first, :last %>
+
+<% if Decidim::Centers.scopes_enabled %>
+  <%= scopes_picker_field f, :scope_id, root: nil %>
+<% end %>

--- a/app/views/decidim/centers/_registration_form.html.erb
+++ b/app/views/decidim/centers/_registration_form.html.erb
@@ -2,6 +2,10 @@
   <div class="card__content card__centers">
     <div class="field">
       <%= f.collection_select :center_id, f.object.center_options_for_select, :first, :last %>
+
+      <% if Decidim::Centers.scopes_enabled %>
+        <%= scopes_picker_field f, :scope_id, root: nil %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
           update: "%{user_name} updated the %{resource_name} center"
       authorizations:
         new:
-          error: The user has no center configured
+          error: The user has no center or scope configured
       models:
         center:
           fields:

--- a/db/migrate/20231205153627_create_decidim_centers_scope_users.rb
+++ b/db/migrate/20231205153627_create_decidim_centers_scope_users.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateDecidimCentersScopeUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :decidim_centers_scope_users do |t|
+      t.references :decidim_scope, foreign_key: true, index: { name: "index_decidim_scope_users_on_decidim_scope_id" }
+      t.references :decidim_user, foreign_key: true, index: { name: "index_decidim_scope_users_on_decidim_user_id" }
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/decidim/centers.rb
+++ b/lib/decidim/centers.rb
@@ -9,5 +9,11 @@ module Decidim
   # This namespace holds the logic of the `Centers` module. This module
   # allows users to create centers in a participatory space.
   module Centers
+    include ActiveSupport::Configurable
+
+    # if false, it won't ask the user for the scope
+    config_accessor :scopes_enabled do
+      true
+    end
   end
 end

--- a/lib/decidim/centers/engine.rb
+++ b/lib/decidim/centers/engine.rb
@@ -46,12 +46,15 @@ module Decidim
           Decidim::Admin::ResourcePermissionsController.include(Decidim::Centers::Admin::NeedsSelect2Snippets)
           Decidim::Devise::SessionsController.include(Decidim::Centers::Devise::SessionsControllerOverride)
           Decidim::Devise::OmniauthRegistrationsController.include(Decidim::Centers::Devise::OmniauthRegistrationsControllerOverride)
+          Decidim::Devise::OmniauthRegistrationsController.include(Decidim::Centers::WithScopesHelper)
+          Decidim::Devise::RegistrationsController.include(Decidim::Centers::WithScopesHelper)
         end
       end
 
       initializer "decidim_centers.sync" do
         ActiveSupport::Notifications.subscribe "decidim.centers.user.updated" do |_name, data|
           Decidim::Centers::SyncCenterUserJob.perform_now(data)
+          Decidim::Centers::SyncScopeUserJob.perform_now(data) if Decidim::Centers.scopes_enabled
           Decidim::Centers::AutoVerificationJob.perform_later(data[:user_id])
         end
       end

--- a/lib/decidim/centers/test/factories.rb
+++ b/lib/decidim/centers/test/factories.rb
@@ -17,4 +17,9 @@ FactoryBot.define do
     user { create :user }
     center { create :center, organization: user.organization }
   end
+
+  factory :scope_user, class: "Decidim::Centers::ScopeUser" do
+    user { create :user }
+    scope { create :scope, organization: user.organization }
+  end
 end

--- a/lib/decidim/centers/test/shared_contexts.rb
+++ b/lib/decidim/centers/test/shared_contexts.rb
@@ -1,13 +1,22 @@
 # frozen_string_literal: true
 
-def check_center_authorization(authorization, user, center)
+def check_center_authorization(authorization, user, center, scope = nil)
   expect(authorization.name).to eq("center")
   expect(authorization.user).to eq(user)
   expect(authorization.metadata["centers"]).to include(center.id)
+  expect(authorization.metadata["scopes"]).to include(scope.id) if scope
 end
 
 shared_examples_for "no authorization is created" do
   it "does not create an authorization" do
     expect { subject.perform_now(params) }.not_to change(Decidim::Authorization, :count)
+  end
+end
+
+shared_context "with scopes disabled" do
+  let(:scope) { nil }
+
+  before do
+    allow(Decidim::Centers).to receive(:scopes_enabled).and_return(false)
   end
 end

--- a/spec/commands/decidim/centers/create_or_update_scope_user_spec.rb
+++ b/spec/commands/decidim/centers/create_or_update_scope_user_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Centers
+    describe CreateOrUpdateScopeUser do
+      subject { described_class.new(scope, user) }
+
+      let(:organization) { create :organization }
+      let(:user) { create :user, organization: organization }
+      let(:scope) { create :scope, organization: organization }
+
+      context "when the user and scope organizations are different" do
+        let(:other_organization) { create :organization }
+        let(:scope) { create :scope, organization: other_organization }
+
+        it "is not valid" do
+          expect { subject.call }.to broadcast(:invalid)
+        end
+      end
+
+      context "when everything is ok" do
+        context "when the user has no scope" do
+          it "increases the number of scope users" do
+            expect { subject.call }.to change(ScopeUser, :count).by(1)
+          end
+        end
+
+        context "when the user already has a scope" do
+          let!(:scope_user) { create :scope_user, user: user }
+
+          it "does not increase the number of scope users" do
+            expect { subject.call }.not_to change(ScopeUser, :count)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/decidim/centers/verifications/center_spec.rb
+++ b/spec/forms/decidim/centers/verifications/center_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "decidim/centers/test/shared_contexts"
 
 module Decidim
   module Centers
@@ -17,22 +18,60 @@ module Decidim
         let(:center_user) { create :center_user }
         let(:metadata) do
           {
-            centers: [center_user.center.id]
+            centers: [center_user.center.id],
+            scopes: []
           }
         end
 
-        context "when everything is ok" do
-          it { is_expected.to be_valid }
+        context "when scopes are disabled" do
+          include_context "with scopes disabled"
 
-          it "returns valid metadata" do
-            expect(subject.metadata).to eq(metadata)
+          context "when the user has no center" do
+            let(:user) { create :user }
+
+            it { is_expected.not_to be_valid }
           end
         end
 
-        context "when the user has no center" do
-          let(:user) { create :user }
+        context "when scopes are enabled" do
+          let(:metadata) do
+            {
+              centers: [center_user.center.id],
+              scopes: [scope_user.scope.id]
+            }
+          end
 
-          it { is_expected.not_to be_valid }
+          context "when the user has no center" do
+            let(:user) { create :user }
+
+            context "when the user has no scope" do
+              let(:scope_user) { create :scope_user }
+
+              it { is_expected.not_to be_valid }
+            end
+
+            context "when the user has scope" do
+              let!(:scope_user) { create :scope_user, user: user }
+
+              it { is_expected.not_to be_valid }
+            end
+          end
+
+          context "when the user has center" do
+            context "when the user has no scope" do
+              it { is_expected.not_to be_valid }
+            end
+
+            context "when the user has scope" do
+              let!(:scope_user) { create :scope_user, user: user }
+
+              it { is_expected.to be_valid }
+
+              it "returns valid metadata" do
+                expect(subject.metadata).to eq(metadata)
+              end
+            end
+          end
         end
       end
     end

--- a/spec/jobs/centers/auto_verification_job_spec.rb
+++ b/spec/jobs/centers/auto_verification_job_spec.rb
@@ -23,7 +23,7 @@ module Decidim
           allow(Rails.logger).to receive(:error).and_call_original
         end
 
-        context "when the user has no center" do
+        context "when the user has no center neither scope" do
           it_behaves_like "no authorization is created"
 
           context "when there is a previous authorization for the user" do
@@ -48,8 +48,9 @@ module Decidim
           end
         end
 
-        context "when the user has center" do
+        context "when the user has center and scope" do
           let!(:center_user) { create :center_user, user: user }
+          let!(:scope_user) { create :scope_user, user: user }
 
           it "creates an authorization" do
             expect { subject.perform_now(params) }.to change(Decidim::Authorization, :count).by(1)

--- a/spec/jobs/centers/sync_scope_user_job_spec.rb
+++ b/spec/jobs/centers/sync_scope_user_job_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Centers
+    describe SyncScopeUserJob do
+      subject { described_class }
+
+      describe "queue" do
+        it "is queued to events" do
+          expect(subject.queue_name).to eq "default"
+        end
+      end
+
+      describe "perform" do
+        let(:user) { create :user }
+        let(:scope) { create :scope }
+        let(:params) { { user_id: user.id, scope_id: scope.id } }
+
+        before do
+          allow(Rails.logger).to receive(:info).and_call_original
+          allow(Rails.logger).to receive(:error).and_call_original
+          subject.perform_now(params)
+        end
+
+        context "when the sync runs successfully" do
+          it "writes an info log" do
+            expect(Rails.logger).to have_received(:info).with(/SyncScopeUserJob: Success/)
+          end
+        end
+
+        context "when the sync fails" do
+          before do
+            # rubocop: disable RSpec/AnyInstance
+            allow_any_instance_of(Decidim::Centers::CreateOrUpdateScopeUser).to receive(:delete_existing_scope_user!).and_raise
+            # rubocop: enable RSpec/AnyInstance
+          end
+
+          it "writes an error log" do
+            expect(Rails.logger).to have_received(:error).with(/SyncScopeUserJob: ERROR/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -19,6 +19,7 @@ checksums = [
       "/app/commands/decidim/create_registration.rb" => "8bf3456d42c21036d08ccafe16e9105a",
       "/app/commands/decidim/update_account.rb" => "29d81617f5bf1af310d2777a916b4d8b",
       "/app/controllers/decidim/devise/omniauth_registrations_controller.rb" => "05bc35af4b5f855736f14efbd22e439b",
+      "/app/controllers/decidim/devise/registrations_controller.rb" => "315c5b3865ecad9d647b4da98057407f",
       "/app/controllers/decidim/devise/sessions_controller.rb" => "235cbe9844cdd39f65c72d3dc87f5f23",
       "/app/forms/decidim/account_form.rb" => "73a8150ed1620d515a1c96f680e98ec0",
       "/app/forms/decidim/omniauth_registration_form.rb" => "ee09e2b5675c9d1cb4dc955dded05393",

--- a/spec/models/decidim/centers/scope_user_spec.rb
+++ b/spec/models/decidim/centers/scope_user_spec.rb
@@ -4,26 +4,26 @@ require "spec_helper"
 
 module Decidim
   module Centers
-    describe CenterUser do
-      subject { center_user }
+    describe ScopeUser do
+      subject { scope_user }
 
-      let(:center_user) { build :center_user }
+      let(:scope_user) { build :scope_user }
 
       it { is_expected.to be_valid }
 
       describe "same_organization" do
         let(:organization) { create :organization }
         let(:other_organization) { create :organization }
-        let(:center) { create :center, organization: organization }
+        let(:scope) { create :scope, organization: organization }
         let(:user) { create :user, organization: other_organization }
-        let(:center_user) { build :center_user, center: center, user: user }
+        let(:scope_user) { build :scope_user, scope: scope, user: user }
 
         it { is_expected.not_to be_valid }
       end
 
       describe "unique_by_user" do
-        let!(:other_center_user) { create :center_user }
-        let(:center_user) { build :center_user, user: other_center_user.user }
+        let!(:other_scope_user) { create :scope_user }
+        let(:scope_user) { build :scope_user, user: other_scope_user.user }
 
         it { is_expected.not_to be_valid }
       end

--- a/spec/models/decidim/user_spec.rb
+++ b/spec/models/decidim/user_spec.rb
@@ -8,33 +8,67 @@ module Decidim
 
     let(:user) { create :user }
 
-    context "without center" do
-      it "has no center_users" do
-        expect(subject.center_users).to eq []
+    describe "centers" do
+      context "without center" do
+        it "has no center_users" do
+          expect(subject.center_users).to eq []
+        end
+
+        it "has no centers" do
+          expect(subject.centers).to eq []
+        end
+
+        it "has no center" do
+          expect(subject.center).to be_nil
+        end
       end
 
-      it "has no centers" do
-        expect(subject.centers).to eq []
-      end
+      context "with center" do
+        let!(:center_user) { create :center_user, user: user }
 
-      it "has no center" do
-        expect(subject.center).to be_nil
+        it "has center_users" do
+          expect(subject.center_users).to eq Centers::CenterUser.all
+        end
+
+        it "has no centers" do
+          expect(subject.centers).to eq Centers::Center.all
+        end
+
+        it "has no center" do
+          expect(subject.center).to eq Centers::Center.first
+        end
       end
     end
 
-    context "with center" do
-      let!(:center_user) { create :center_user, user: user }
+    describe "scopes" do
+      context "without scope" do
+        it "has no scope_users" do
+          expect(subject.scope_users).to eq []
+        end
 
-      it "has center_users" do
-        expect(subject.center_users).to eq Centers::CenterUser.all
+        it "has no scopes" do
+          expect(subject.scopes).to eq []
+        end
+
+        it "has no scope" do
+          expect(subject.scope).to be_nil
+        end
       end
 
-      it "has no centers" do
-        expect(subject.centers).to eq Centers::Center.all
-      end
+      context "with scope" do
+        let!(:scope_user) { create :scope_user, user: user }
 
-      it "has no center" do
-        expect(subject.center).to eq Centers::Center.first
+        it "has scope_users" do
+          expect(subject.scope_users).to eq Centers::ScopeUser.all
+        end
+
+        it "has no scopes" do
+          expect(subject.scopes).to eq Scope.all
+        end
+
+        it "has no scope" do
+          expect(subject.scope).to eq Scope.first
+        end
       end
     end
   end

--- a/spec/system/account_spec.rb
+++ b/spec/system/account_spec.rb
@@ -8,10 +8,64 @@ describe "Account", type: :system do
   let(:user) { create :user, :confirmed, organization: organization }
   let!(:center) { create :center, organization: organization }
   let!(:other_center) { create :center, organization: organization }
+  let!(:scope) { create :scope, organization: organization }
+  let!(:other_scope) { create :scope, organization: organization }
 
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
+  end
+
+  shared_context "when visiting account path" do
+    before do
+      visit decidim.account_path
+    end
+  end
+
+  shared_context "with authorization" do
+    let!(:authorization) { create :authorization, name: "center", user: user, metadata: { centers: [center.id], scopes: [scope&.id].compact } }
+  end
+
+  shared_context "with user with center" do
+    let!(:center_user) { create :center_user, center: center, user: user }
+
+    include_context "when visiting account path"
+  end
+
+  shared_context "with user with scope" do
+    let!(:scope_user) { create :scope_user, scope: scope, user: user }
+
+    include_context "when visiting account path"
+  end
+
+  shared_examples_for "user without center changes the center" do
+    it "shows an empty value on the center input" do
+      expect(find("#user_center_id").value).to eq("")
+    end
+
+    include_examples "user changes the center"
+  end
+
+  shared_examples_for "user with center changes the center" do
+    it "has an authorization for the center" do
+      check_center_authorization(Decidim::Authorization.last, user, center)
+    end
+
+    it "shows the current center on the center input" do
+      expect(find("#user_center_id").value).to eq(center.id.to_s)
+    end
+
+    include_examples "user changes the center"
+  end
+
+  shared_examples_for "user cannot be saved without changes" do
+    it "cannot save without selecting center" do
+      within "form.edit_user" do
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_content("There's an error in this field").or have_content("can't be blank")
+    end
   end
 
   shared_examples_for "user changes the center" do
@@ -35,34 +89,108 @@ describe "Account", type: :system do
     end
   end
 
-  context "when the user doesn't have center" do
-    before do
-      visit decidim.account_path
+  shared_examples_for "user without scope changes the scope" do
+    it "shows an empty value on the scope input" do
+      within "#user_scope_id" do
+        expect(page).to have_content("Global scope")
+      end
     end
 
-    it "shows an empty value on the center input" do
-      expect(find("#user_center_id").value).to eq("")
-    end
-
-    include_examples "user changes the center"
+    include_examples "user changes the scope", false
   end
 
-  context "when the user has center" do
-    let!(:center_user) { create :center_user, center: center, user: user }
-    let!(:authorization) { create :authorization, name: "center", user: user, metadata: { centers: [center.id] } }
-
-    before do
-      visit decidim.account_path
+  shared_examples_for "user with scope changes the scope" do
+    it "has an authorization for the center and the scope" do
+      check_center_authorization(Decidim::Authorization.last, user, center, scope)
     end
 
-    it "has an authorization for the center" do
-      check_center_authorization(Decidim::Authorization.last, user, center)
+    it "shows the current scope on the scope input" do
+      within "#user_scope_id" do
+        expect(page).to have_content(scope.name["en"])
+      end
     end
 
-    it "shows the current center on the center input" do
-      expect(find("#user_center_id").value).to eq(center.id.to_s)
+    include_examples "user changes the scope", true
+  end
+
+  shared_examples_for "user changes the scope" do |has_scope|
+    it "can update the scope and changes the authorization" do
+      within "form.edit_user" do
+        if has_scope
+          scope_repick :user_scope_id, scope, other_scope
+        else
+          scope_pick select_data_picker(:user_scope_id), other_scope
+        end
+
+        find("*[type=submit]").click
+      end
+
+      within_flash_messages do
+        expect(page).to have_content("successfully")
+      end
+
+      within "#user_scope_id .picker-values" do
+        expect(page).to have_content(other_scope.name["en"])
+      end
+
+      perform_enqueued_jobs
+      check_center_authorization(Decidim::Authorization.last, user, center, other_scope)
+    end
+  end
+
+  include_context "when visiting account path"
+
+  context "when the scopes are disabled" do
+    include_context "with scopes disabled"
+    include_context "when visiting account path"
+
+    it "doesn't show the scope input" do
+      expect(page).not_to have_selector("#user_scope_id")
     end
 
-    include_examples "user changes the center"
+    context "when the user doesn't have center" do
+      include_examples "user cannot be saved without changes"
+      include_examples "user without center changes the center"
+    end
+
+    context "when the user has center" do
+      include_context "with user with center"
+      include_context "with authorization"
+
+      include_examples "user with center changes the center"
+    end
+  end
+
+  context "when the scopes are enabled" do
+    include_context "when visiting account path"
+
+    context "when the user doesn't have scope" do
+      context "when the user doesn't have center" do
+        include_examples "user cannot be saved without changes"
+      end
+
+      context "when the user has center" do
+        include_context "with user with center"
+        include_context "with authorization"
+
+        include_examples "user cannot be saved without changes"
+        include_examples "user without scope changes the scope"
+      end
+    end
+
+    context "when the user has scope" do
+      include_context "with user with scope"
+
+      context "when the user doesn't have center" do
+        include_examples "user cannot be saved without changes"
+      end
+
+      context "when the user has center" do
+        include_context "with user with center"
+        include_context "with authorization"
+
+        include_examples "user with scope changes the scope"
+      end
+    end
   end
 end

--- a/spec/system/registration_spec.rb
+++ b/spec/system/registration_spec.rb
@@ -11,6 +11,8 @@ describe "Registration spec", type: :system do
   let(:password) { Faker::Internet.password(min_length: 17) }
   let!(:center) { create :center, organization: organization }
   let!(:other_center) { create :center, organization: organization }
+  let!(:scope) { create :scope, organization: organization }
+  let!(:other_scope) { create :scope, organization: organization }
 
   before do
     switch_to_host(organization.host)
@@ -23,21 +25,37 @@ describe "Registration spec", type: :system do
     end
   end
 
+  it "contains scope field" do
+    within ".card__centers" do
+      expect(page).to have_content("Scope")
+    end
+  end
+
   it "displays center as mandatory" do
-    within "label[for='registration_user_center_id']" do
+    within ".card__centers label[for='registration_user_center_id']" do
       expect(page).to have_css("span.label-required")
     end
   end
 
-  it "allows to create a new account and authorizes the user with the center provided" do
+  it "displays scope as mandatory" do
+    within all(".card__centers label").last do
+      expect(page).to have_css("span.label-required")
+    end
+  end
+
+  it "allows to create a new account and authorizes the user with the center and scope provided" do
     fill_in :registration_user_name, with: name
     fill_in :registration_user_nickname, with: nickname
     fill_in :registration_user_email, with: email
     fill_in :registration_user_password, with: password
     fill_in :registration_user_password_confirmation, with: password
 
-    within "#registration_user_center_id" do
-      find("option[value='#{center.id}']").click
+    within ".card__centers" do
+      within "#registration_user_center_id" do
+        find("option[value='#{center.id}']").click
+      end
+
+      scope_pick select_data_picker(:registration_user), scope
     end
 
     page.check("registration_user_newsletter")
@@ -49,8 +67,21 @@ describe "Registration spec", type: :system do
 
     expect(page).to have_content("message with a confirmation link has been sent")
     expect(Decidim::User.last.center).to eq(center)
+    expect(Decidim::User.last.scope).to eq(scope)
 
     perform_enqueued_jobs
-    check_center_authorization(Decidim::Authorization.last, Decidim::User.last, center)
+    check_center_authorization(Decidim::Authorization.last, Decidim::User.last, center, scope)
+  end
+
+  context "with scopes disabled" do
+    include_context "with scopes disabled"
+
+    before do
+      visit decidim.new_user_registration_path
+    end
+
+    it "doesn't show the scope input" do
+      expect(page).not_to have_content("Global scope")
+    end
   end
 end


### PR DESCRIPTION
Fixes #4  
Fixes #6
Fixes #8
Fixes #10
Fixes #17

https://github.com/Platoniq/decidim-module-centers/assets/6973564/c693599a-8fc6-40ee-af48-f352263e9db1

- [x] Create a model to relate scopes and users
- [x] Create a command to create a relationship between the user and the scope taking into account we only want one scope by user
- [x] Include functionality to the user model to return the user scope
- [x] As a user, I can select my scope on the registration page
- [x] As a user, I can change my scope from my account page
- [x] An authorization with the scope the user selects in the metadata is created (the same that the used for the centers) when the user registers in the platform
- [x] The scope authorization is updated when the user updates the scope in the account page
- [ ] As an admin, I want to restrict access to spaces and components to users with specific scopes
- [ ] As a user trying to access a resource for a specific scope, I can only access it if I'm in that scope
- [ ] If the center is also specified, you'll only be able to access the resource if both the center and the scope match
- [x] Make configurable the usage of scopes